### PR TITLE
Send a correct Content-Type for device icons

### DIFF
--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -813,6 +813,11 @@ func (server *Server) initMux(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	for i, di := range server.Icons {
 		mux.HandleFunc(fmt.Sprintf("%s/%d", deviceIconPath, i), func(w http.ResponseWriter, r *http.Request) {
+                        w.Header().Set("Content-Type", di.Mimetype)
+                        ext, _ := mime.ExtensionsByType(di.Mimetype)
+                        if ext != nil && len(ext) > 0 {
+                                w.Header().Set("Ext", strings.TrimPrefix(ext[0], "."))
+                        }
 			http.ServeContent(w, r, "", time.Time{}, di.ReadSeeker)
 		})
 	}


### PR DESCRIPTION
Currently DMS sends "Content-Type: text/plain" for device icon requests which may confuse some clients. The reason is that http.ServeContent can't deduce a correct type and uses a default value.