### PR TITLE
Add flag to disable ffprobe

### DIFF
--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -71,21 +71,24 @@ func (me *contentDirectoryService) cdsObjectToUpnpavObject(cdsObject object, fil
 	obj.AlbumArtURI = iconURI
 	obj.Class = "object.item." + string(mimeTypeType) + "Item"
 	var (
+		ffInfo        *ffprobe.Info
 		nativeBitrate uint
 		resDuration   string
 	)
-	ffInfo, probeErr := me.ffmpegProbe(entryFilePath)
-	switch probeErr {
-	case nil:
-		if ffInfo != nil {
-			nativeBitrate, _ = ffInfo.Bitrate()
-			if d, err := ffInfo.Duration(); err == nil {
-				resDuration = misc.FormatDurationSexagesimal(d)
+	if !me.NoProbe {
+		ffInfo, probeErr := me.ffmpegProbe(entryFilePath)
+		switch probeErr {
+		case nil:
+			if ffInfo != nil {
+				nativeBitrate, _ = ffInfo.Bitrate()
+				if d, err := ffInfo.Duration(); err == nil {
+					resDuration = misc.FormatDurationSexagesimal(d)
+				}
 			}
+		case ffprobe.ExeNotFound:
+		default:
+			log.Printf("error probing %s: %s", entryFilePath, probeErr)
 		}
-	case ffprobe.ExeNotFound:
-	default:
-		log.Printf("error probing %s: %s", entryFilePath, probeErr)
 	}
 	if obj.Title == "" {
 		obj.Title = fileInfo.Name()

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -232,6 +232,8 @@ type Server struct {
 	LogHeaders bool
 	// Disable transcoding, and the resource elements implied in the CDS.
 	NoTranscode bool
+	// Disable media probing with ffprobe
+	NoProbe     bool
 	Icons       []Icon
 	// Stall event subscription requests until they drop. A workaround for
 	// some bad clients.

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type dmsConfig struct {
 	LogHeaders          bool
 	FFprobeCachePath    string
 	NoTranscode         bool
+	NoProbe             bool
 	StallEventSubscribe bool
 }
 
@@ -103,6 +104,7 @@ func main() {
 	fFprobeCachePath := flag.String("fFprobeCachePath", config.FFprobeCachePath, "path to FFprobe cache file")
 	configFilePath := flag.String("config", "", "json configuration file")
 	flag.BoolVar(&config.NoTranscode, "noTranscode", false, "disable transcoding")
+	flag.BoolVar(&config.NoProbe, "noProbe", false, "disable media probing with ffprobe")
 	flag.BoolVar(&config.StallEventSubscribe, "stallEventSubscribe", false, "workaround for some bad event subscribers")
 
 	flag.Parse()
@@ -166,6 +168,7 @@ func main() {
 		FFProbeCache:   cache,
 		LogHeaders:     config.LogHeaders,
 		NoTranscode:    config.NoTranscode,
+		NoProbe:        config.NoProbe,
 		Icons: []dms.Icon{
 			dms.Icon{
 				Width:      48,


### PR DESCRIPTION
Thanks a lot for the code.

This PR adds a `-noProbe` command line flag to disable ffprobe. This is useful to reduce network load when browsing remote folders over a FUSE filesystem.