### PR TITLE
Error handling and logging improvements

### DIFF
--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -319,7 +319,7 @@ func (o *object) FilePath() string {
 // Returns the ObjectID for the object. This is used in various ContentDirectory actions.
 func (o object) ID() string {
 	if !path.IsAbs(o.Path) {
-		panic(o.Path)
+		log.Panicf("Relative object path: %s", o.Path)
 	}
 	if len(o.Path) == 1 {
 		return "0"

--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -51,6 +51,7 @@ func (me *contentDirectoryService) cdsObjectToUpnpavObject(cdsObject object, fil
 		return
 	}
 	if !fileInfo.Mode().IsRegular() {
+		log.Printf("%s ignored: non-regular file", cdsObject.FilePath())
 		return
 	}
 	mimeType, err := MimeTypeByPath(entryFilePath)
@@ -58,6 +59,7 @@ func (me *contentDirectoryService) cdsObjectToUpnpavObject(cdsObject object, fil
 		return
 	}
 	if !mimeType.IsMedia() {
+		log.Printf("%s ignored: non-media file (%s)", cdsObject.FilePath(), mimeType)
 		return
 	}
 	iconURI := (&url.URL{
@@ -169,6 +171,7 @@ func (me *contentDirectoryService) readContainer(o object, host, userAgent strin
 		child := object{path.Join(o.Path, fi.Name()), me.RootObjectPath}
 		obj, err := me.cdsObjectToUpnpavObject(child, fi, host, userAgent)
 		if err != nil {
+			log.Printf("error with %s: %s", child.FilePath(), err)
 			continue
 		}
 		if obj != nil {

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -903,6 +903,7 @@ func (server *Server) IgnorePath(path string) (bool, error) {
 		if hidden, err := isHiddenPath(path); err != nil {
 			return false, err
 		} else if hidden {
+			log.Print(path, " ignored: hidden")
 			return true, nil
 		}
 	}
@@ -910,6 +911,7 @@ func (server *Server) IgnorePath(path string) (bool, error) {
 		if readable, err := isReadablePath(path); err != nil {
 			return false, err
 		} else if !readable {
+			log.Print(path, " ignored: unreadable")
 			return true, nil
 		}
 	}

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -613,7 +613,8 @@ func (server *Server) contentDirectoryInitialEvent(urls []*url.URL, sid string) 
 		bodyReader := bytes.NewReader(body)
 		req, err := http.NewRequest("NOTIFY", _url.String(), bodyReader)
 		if err != nil {
-			panic(err)
+			log.Printf("Could not create a request to notify %s: %s", _url.String(), err)
+			continue
 		}
 		req.Header["CONTENT-TYPE"] = []string{`text/xml; charset="utf-8"`}
 		req.Header["NT"] = []string{"upnp:event"}

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -752,20 +752,23 @@ func (server *Server) initMux(mux *http.ServeMux) {
 	}
 }
 
-func (s *Server) initServices() {
+func (s *Server) initServices() (err error) {
 	urn, err := upnp.ParseServiceType(services[0].ServiceType)
 	if err != nil {
-		panic(err)
+		return
 	}
 	s.services = map[string]UPnPService{
 		urn.Type: &contentDirectoryService{
 			Server: s,
 		},
 	}
+	return
 }
 
 func (srv *Server) Serve() (err error) {
-	srv.initServices()
+	if err = srv.initServices(); err != nil {
+		return
+	}
 	srv.closed = make(chan struct{})
 	if srv.FriendlyName == "" {
 		srv.FriendlyName = getDefaultFriendlyName()

--- a/dlna/dms/mimetype.go
+++ b/dlna/dms/mimetype.go
@@ -1,6 +1,7 @@
 package dms
 
 import (
+	"log"
 	"mime"
 	"net/http"
 	"os"
@@ -10,10 +11,10 @@ import (
 
 func init() {
 	if err := mime.AddExtensionType(".rmvb", "application/vnd.rn-realmedia-vbr"); err != nil {
-		panic(err)
+		log.Printf("Could not register application/vnd.rn-realmedia-vbr MIME type: %s", err)
 	}
 	if err := mime.AddExtensionType(".ogv", "video/ogg"); err != nil {
-		panic(err)
+		log.Printf("Could not register video/ogg MIME type: %s", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -90,7 +90,8 @@ func (fc *fFprobeCache) Set(key interface{}, value interface{}) {
 	for _, v := range []interface{}{key, value} {
 		b, err := json.Marshal(v)
 		if err != nil {
-			panic(err)
+			log.Printf("Could not marshal %v: %s", v, err)
+			continue
 		}
 		size += int64(len(b))
 	}

--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -32,7 +32,7 @@ func init() {
 	var err error
 	NetAddr, err = net.ResolveUDPAddr("udp4", AddrString)
 	if err != nil {
-		panic(err)
+		log.Panicf("Could not resolve %s: %s", AddrString, err)
 	}
 }
 
@@ -116,7 +116,7 @@ func (me *Server) serve() {
 		default:
 		}
 		if err != nil {
-			log.Print(err)
+			log.Printf("error reading from UDP socket: %s", err)
 			break
 		}
 		go me.handle(b[:n], addr)
@@ -262,9 +262,10 @@ func (me *Server) handle(buf []byte, sender *net.UDPAddr) {
 	}
 	var mx uint
 	if req.Header.Get("Host") == AddrString {
-		i, err := strconv.ParseUint(req.Header.Get("mx"), 0, 0)
+		mxHeader := req.Header.Get("mx")
+		i, err := strconv.ParseUint(mxHeader, 0, 0)
 		if err != nil {
-			log.Println(err)
+			log.Printf("Invalid mx header %q: %s", mxHeader, err)
 			return
 		}
 		mx = uint(i)

--- a/upnp/upnp.go
+++ b/upnp/upnp.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,8 +28,7 @@ func ParseServiceType(s string) (ret ServiceURN, err error) {
 		return
 	}
 	if len(matches) != 3 {
-		err = errors.New(s)
-		return
+		log.Panicf("Invalid serviceURNRegexp ?")
 	}
 	ret.Type = matches[1]
 	ret.Version, err = strconv.ParseUint(matches[2], 0, 0)
@@ -40,7 +40,7 @@ type SoapAction struct {
 	Action string
 }
 
-func ParseActionHTTPHeader(s string) (ret SoapAction, ok bool) {
+func ParseActionHTTPHeader(s string) (ret SoapAction, err error) {
 	if s[0] != '"' || s[len(s)-1] != '"' {
 		return
 	}
@@ -50,11 +50,7 @@ func ParseActionHTTPHeader(s string) (ret SoapAction, ok bool) {
 		return
 	}
 	ret.Action = s[hashIndex+1:]
-	var err error
 	ret.ServiceURN, err = ParseServiceType(s[:hashIndex])
-	if err == nil {
-		ok = true
-	}
 	return
 }
 

--- a/upnp/upnp.go
+++ b/upnp/upnp.go
@@ -102,21 +102,36 @@ type Error struct {
 	Desc    string   `xml:"errorDescription"`
 }
 
+func (e *Error) Error() string {
+	return fmt.Sprintf("%d %s", e.Code, e.Desc)
+}
+
 const (
 	InvalidActionErrorCode        = 401
+	ActionFailedErrorCode         = 501
 	ArgumentValueInvalidErrorCode = 600
 )
 
 var (
-	InvalidActionError Error = Error{
-		Code: 401,
-		Desc: "Invalid Action",
-	}
-	ArgumentValueInvalidError = Error{
-		Code: 600,
-		Desc: "The argument value is invalid",
-	}
+	InvalidActionError        = Errorf(401, "Invalid Action")
+	ArgumentValueInvalidError = Errorf(600, "The argument value is invalid")
 )
+
+// Errorf creates an UPNP error from the given code and description
+func Errorf(code uint, tpl string, args ...interface{}) *Error {
+	return &Error{Code: code, Desc: fmt.Sprintf(tpl, args...)}
+}
+
+// ConvertError converts any error to an UPNP error
+func ConvertError(err error) *Error {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(*Error); ok {
+		return e
+	}
+	return Errorf(ActionFailedErrorCode, err.Error())
+}
 
 type Action struct {
 	Name      string


### PR DESCRIPTION
I have tried to apply the following guidelines:
* If the error results only in something being ignored (e.g. not listed) without compromising the whole request, log and ignore it.
* If an error should never happen or prevent dms to work at all, log it and panic.
* Else, bubble the error up.
* `*upnp.Error` implements the `error` interface and `upnp.Errorf` allows to create such error.
* Log why file/directories are ignored (this can be a bit verbose).

I think that few panic()/log.Panicf() can still be rewritten to return the error instead.

About logging: it will be hard to do better without a leveled, structured log system.