### PR TITLE
Update what seems to be a mandatory argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,8 @@ dms
     :target: https://circleci.com/gh/anacrolix/dms
 
 dms is a UPnP DLNA Digital Media Server. It runs from the terminal, and serves
-content directly from the filesystem from the working directory, or the path
-given. The SSDP component will broadcast and respond to requests on all
-available network interfaces.
+content directly from the filesystem from the path given. The SSDP component
+will broadcast and respond to requests on all available network interfaces.
 
 dms advertises and serves the raw files, in addition to alternate transcoded
 streams when it's able, such as mpeg2 PAL-DVD and WebM for the Chromecast. It
@@ -28,7 +27,7 @@ Ensure ``ffmpeg``/``avconv`` and/or ``ffmpegthumbnailer`` are in the ``PATH`` if
 
 To run::
 
-    $ "$GOPATH"/bin/dms
+    $ "$GOPATH"/bin/dms -path $(pwd)
 
 Known Compatible Players and Renderers
 ======================================


### PR DESCRIPTION
Unless I'm mistaken, this seems necessary. I was getting constantly "Path must be absolute:" errors otherwise.

Also, I was confused by you not recommending just using `go install github.com/anacrolix/dms` after go get (a minor nitpick).

Are there any unwanted side effects in doing so?

After a little research, it seems that this PR broke what used to be a functionality (reading from working directory): https://github.com/anacrolix/dms/pull/45.

Although, IMO, passing a path argument seems very reasonable.