### PR TITLE
Add cidr notation support

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,6 @@ func main() {
 		log.Printf("allowed ips are %q", config.AllowedIps)
 	}
 
-	os.Exit(0)
 	if len(*configFilePath) > 0 {
 		config.load(*configFilePath)
 	}


### PR DESCRIPTION
Sorry to bother you again. But here is something I consider to be really useful. The allowed ip list does not support cidr notation. Quite good if you want to allow a range of addresses.  You can use something like "192.168.0.0/27" for example. Cheers.