### PR TITLE
Fix chromecast transcode

### DIFF
--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -125,7 +125,7 @@ func ChromecastTranscode(path string, start, length time.Duration, stderr io.Wri
 		"-ss", FormatDurationSexagesimal(start),
 		"-i", path,
 		"-c:v", "libx264", "-preset", "ultrafast", "-profile:v", "high", "-level", "5.0",
-		"-movflags", "+faststart",
+		"-movflags", "+faststart+frag_keyframe+empty_moov",
 	}
 	if length > 0 {
 		args = append(args, []string{


### PR DESCRIPTION
The Chromecast transcoding seems to be broken. Ffmpeg exited saying: "muxer does not support non seekable output". I had to add two parameters to movflags. If you see this too here is the fix.