### PR TITLE
Add 'force transcode to' cli switch

### DIFF
--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -231,6 +231,8 @@ type Server struct {
 	LogHeaders bool
 	// Disable transcoding, and the resource elements implied in the CDS.
 	NoTranscode bool
+	// Force transcoding to certain format of the 'transcodes' map
+	ForceTranscodeTo string
 	// Disable media probing with ffprobe
 	NoProbe bool
 	Icons   []Icon
@@ -728,7 +730,12 @@ func (server *Server) initMux(mux *http.ServeMux) {
 			http.Error(w, "no such object", http.StatusNotFound)
 			return
 		}
-		k := r.URL.Query().Get("transcode")
+		var k string
+		if server.ForceTranscodeTo != "" {
+			k = server.ForceTranscodeTo
+		} else {
+			k = r.URL.Query().Get("transcode")
+		}
 		if k == "" {
 			mimeType, err := MimeTypeByPath(filePath)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ type dmsConfig struct {
 	LogHeaders          bool
 	FFprobeCachePath    string
 	NoTranscode         bool
+	ForceTranscodeTo    string
 	NoProbe             bool
 	StallEventSubscribe bool
 	NotifyInterval      time.Duration
@@ -68,6 +69,7 @@ var config = &dmsConfig{
 	DeviceIcon:       "",
 	LogHeaders:       false,
 	FFprobeCachePath: getDefaultFFprobeCachePath(),
+	ForceTranscodeTo: "",
 }
 
 func getDefaultFFprobeCachePath() (path string) {
@@ -118,6 +120,7 @@ func main() {
 	fFprobeCachePath := flag.String("fFprobeCachePath", config.FFprobeCachePath, "path to FFprobe cache file")
 	configFilePath := flag.String("config", "", "json configuration file")
 	allowedIps := flag.String("allowedIps", "", "allowed ip of clients, separated by comma")
+	forceTranscodeTo := flag.String("forceTranscodeTo", config.ForceTranscodeTo, "force transcoding to certain format, supported: 'chromecast', 'vp8'")
 	flag.BoolVar(&config.NoTranscode, "noTranscode", false, "disable transcoding")
 	flag.BoolVar(&config.NoProbe, "noProbe", false, "disable media probing with ffprobe")
 	flag.BoolVar(&config.StallEventSubscribe, "stallEventSubscribe", false, "workaround for some bad event subscribers")
@@ -139,6 +142,7 @@ func main() {
 	config.LogHeaders = *logHeaders
 	config.FFprobeCachePath = *fFprobeCachePath
 	config.AllowedIpNets = makeIpNets(*allowedIps)
+	config.ForceTranscodeTo = *forceTranscodeTo
 	// if len(config.AllowedIps) > 0 {
 	log.Printf("allowed ip nets are %q", config.AllowedIpNets)
 	// }
@@ -186,12 +190,13 @@ func main() {
 			}
 			return conn
 		}(),
-		FriendlyName:   config.FriendlyName,
-		RootObjectPath: filepath.Clean(config.Path),
-		FFProbeCache:   cache,
-		LogHeaders:     config.LogHeaders,
-		NoTranscode:    config.NoTranscode,
-		NoProbe:        config.NoProbe,
+		FriendlyName:     config.FriendlyName,
+		RootObjectPath:   filepath.Clean(config.Path),
+		FFProbeCache:     cache,
+		LogHeaders:       config.LogHeaders,
+		NoTranscode:      config.NoTranscode,
+		ForceTranscodeTo: config.ForceTranscodeTo,
+		NoProbe:          config.NoProbe,
 		Icons: []dms.Icon{
 			dms.Icon{
 				Width:      48,


### PR DESCRIPTION
I thought it would be a good idea to have a possibility to force encoding to a certain type because there are clients which are not aware of the "transcode" parameter in the url. If you know what your clients can deal with it is pretty handy if you can simply tell the server what to render to.

This is a first draft that can be made nicer in several ways. For example by trying to distinguish between clients or adding more encoding schemes. Maybe stored in a config file or something. 

But for now this first version makes life easier. What do you think?