### PR TITLE
Add ipv6 support

### DIFF
--- a/main.go
+++ b/main.go
@@ -322,6 +322,8 @@ func makeIpNets(s string) []*net.IPNet {
 	if len(s) < 1 {
 		_, ipnet, _ := net.ParseCIDR("0.0.0.0/0")
 		nets = append(nets, ipnet)
+		_, ipnet, _ = net.ParseCIDR("0:0:0::/128")
+		nets = append(nets, ipnet)
 	} else {
 		for _, el := range strings.Split(s, ",") {
 			ip := net.ParseIP(el)


### PR DESCRIPTION
I had the chance to test with devices having an ipv6. They were denied because the default range of allowed devices was only set in ipv4. Luckily it was easy to fix because the net library does support ipv6 by default. I just had to add the full ipv6 range to the default allowed range.