### PR TITLE
Add Dockerfile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+      ffmpeg \
+      ffmpegthumbnailer \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY . /go/src/github.com/anacrolix/dms/
+WORKDIR /go/src/github.com/anacrolix/dms/
+RUN \
+  go build -v .
+
+ENTRYPOINT [ "./dms" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Golang image, latest tag. More info at https://hub.docker.com/_/golang/

Install package dependencies, add files, set working dir and build. Nothing too fancy.

Build:

```
$ docker build -t dms .
```

Run:

```
$ docker run --net=host --rm -it -v /some/host/dir/:/var/lib/dms/ dms -path /var/lib/dms/ [other options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --net=host --rm -it -v /some/host/dir/:/var/lib/dms/ pataquets/dms-src -path /var/lib/dms/ [other options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.
Choose some existing media dir from your host filesystem to mount inside the container (```-v``` switch).
Uses the `--net=host` switch to access the host's network stack instead of using container port mappings, for simplicity.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.