### PR TITLE
Include more validation for SoapAction header

### DIFF
--- a/upnp/upnp.go
+++ b/upnp/upnp.go
@@ -41,6 +41,9 @@ type SoapAction struct {
 }
 
 func ParseActionHTTPHeader(s string) (ret SoapAction, err error) {
+	if len(s) < 3 {
+		return
+	}
 	if s[0] != '"' || s[len(s)-1] != '"' {
 		return
 	}


### PR DESCRIPTION
Previously, you could trip 500s if the header was absent, with logs like

    runtime error: index out of range [0] with length 0