### PR TITLE
Add new transcoder

### DIFF
--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -57,6 +57,7 @@ var transcodes = map[string]transcodeSpec{
 	},
 	"vp8":        {mimeType: "video/webm", Transcode: transcode.VP8Transcode},
 	"chromecast": {mimeType: "video/mp4", Transcode: transcode.ChromecastTranscode},
+	"web":        {mimeType: "video/mp4", Transcode: transcode.WebTranscode},
 }
 
 func makeDeviceUuid(unique string) string {

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -737,8 +737,8 @@ func (server *Server) initMux(mux *http.ServeMux) {
 		} else {
 			k = r.URL.Query().Get("transcode")
 		}
-		if k == "" {
-			mimeType, err := MimeTypeByPath(filePath)
+		mimeType, err := MimeTypeByPath(filePath)
+		if k == "" || mimeType.IsImage() {
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 	fFprobeCachePath := flag.String("fFprobeCachePath", config.FFprobeCachePath, "path to FFprobe cache file")
 	configFilePath := flag.String("config", "", "json configuration file")
 	allowedIps := flag.String("allowedIps", "", "allowed ip of clients, separated by comma")
-	forceTranscodeTo := flag.String("forceTranscodeTo", config.ForceTranscodeTo, "force transcoding to certain format, supported: 'chromecast', 'vp8'")
+	forceTranscodeTo := flag.String("forceTranscodeTo", config.ForceTranscodeTo, "force transcoding to certain format, supported: 'chromecast', 'vp8', 'web'")
 	flag.BoolVar(&config.NoTranscode, "noTranscode", false, "disable transcoding")
 	flag.BoolVar(&config.NoProbe, "noProbe", false, "disable media probing with ffprobe")
 	flag.BoolVar(&config.StallEventSubscribe, "stallEventSubscribe", false, "workaround for some bad event subscribers")

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -137,3 +137,26 @@ func ChromecastTranscode(path string, start, length time.Duration, stderr io.Wri
 		"pipe:"}...)
 	return transcodePipe(args, stderr)
 }
+
+// Returns a stream of h264 video and mp3 audio
+func WebTranscode(path string, start, length time.Duration, stderr io.Writer) (r io.ReadCloser, err error) {
+	args := []string{
+		"ffmpeg",
+		"-ss", FormatDurationSexagesimal(start),
+		"-i", path,
+		"-pix_fmt", "yuv420p",
+		"-c:v", "libx264", "-crf", "25",
+		"-c:a", "mp3", "-ab", "128k", "-ar", "44100",
+		"-preset", "ultrafast",
+		"-movflags", "+faststart+frag_keyframe+empty_moov",
+	}
+	if length > 0 {
+		args = append(args, []string{
+			"-t", FormatDurationSexagesimal(length),
+		}...)
+	}
+	args = append(args, []string{
+		"-f", "mp4",
+		"pipe:"}...)
+	return transcodePipe(args, stderr)
+}


### PR DESCRIPTION
I started using dms as backend for a web application. Therefore I added a transcoding setting which delivers files that play in the browser. Also transcoding images even when `forceTranscodeTo` is set didn't make sense from my point of view.

Also it would be nice to add transcoding profiles in an easier way. Maybe inside the config file or so. I'll probably investigate this in the future.

Feel free to pull. And thanx again for this nice piece of software.