### PR TITLE
Improve IPv6 support

### DIFF
--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -531,6 +531,10 @@ func (me *Server) soapActionResponse(sa upnp.SoapAction, actionRequestXML []byte
 func (me *Server) serviceControlHandler(w http.ResponseWriter, r *http.Request) {
 	found := false
 	clientIp, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if zoneDelimiterIdx := strings.Index(clientIp, "%"); zoneDelimiterIdx != -1 {
+		// IPv6 addresses may have the form address%zone (e.g. ::1%eth0)
+		clientIp = clientIp[:zoneDelimiterIdx]
+	}
 	for _, ipnet := range me.AllowedIpNets {
 		if ipnet.Contains(net.ParseIP(clientIp)) {
 			found = true

--- a/main.go
+++ b/main.go
@@ -322,7 +322,7 @@ func makeIpNets(s string) []*net.IPNet {
 	if len(s) < 1 {
 		_, ipnet, _ := net.ParseCIDR("0.0.0.0/0")
 		nets = append(nets, ipnet)
-		_, ipnet, _ = net.ParseCIDR("0:0:0::/128")
+		_, ipnet, _ = net.ParseCIDR("::/0")
 		nets = append(nets, ipnet)
 	} else {
 		for _, el := range strings.Split(s, ",") {


### PR DESCRIPTION
I observed that some requests were blocked, with the following error in the `dms` logs:

```
dms.go:540: not allowed client fe80::36e6:d7ff:fe18:9e12%eno1, [0.0.0.0/0 ::/128]
```

The issue is that `request.RemoteAddr` may contain the zone (interface name) in the address.
Then [`net.SplitHostPort`](https://golang.org/pkg/net/#SplitHostPort) may return `host%zone` as its first parameter, which cannot be parsed by `net.ParseIP`.

This pull request drops the `%zone` suffix from the IPv6 address.

It also use `::/0` to accept all IPv6 addresses (equivalent of `0.0.0.0/0` in IPv4)