### PR TITLE
Fix "unix" build constraints

### DIFF
--- a/dlna/dms/dms_others.go
+++ b/dlna/dms/dms_others.go
@@ -1,4 +1,4 @@
-//+build !unix,!windows
+//+build !linux,!darwin,!windows
 
 package dms
 

--- a/dlna/dms/dms_unix.go
+++ b/dlna/dms/dms_unix.go
@@ -1,4 +1,4 @@
-//+build unix
+//+build linux darwin
 
 package dms
 

--- a/dlna/dms/dms_unix_test.go
+++ b/dlna/dms/dms_unix_test.go
@@ -1,4 +1,4 @@
-//+build unix
+//+build linux darwin
 
 package dms
 
@@ -6,16 +6,16 @@ import "testing"
 
 func TestIsHiddenPath(t *testing.T) {
 	var data = map[string]bool{
-		"/some/path": false,
-		"/some/foo.bar": false,
+		"/some/path":         false,
+		"/some/foo.bar":      false,
 		"/some/path/.hidden": true,
 		"/some/.hidden/path": true,
-		"/.hidden/path": true,
+		"/.hidden/path":      true,
 	}
 	for path, expected := range data {
 		if actual, err := isHiddenPath(path); err != nil {
 			t.Errorf("isHiddenPath(%v) returned unexpected error: %s", path, err)
-		] else if expected != actual {
+		} else if expected != actual {
 			t.Errorf("isHiddenPath(%v), expected %v, got %v", path, expected, actual)
 		}
 	}


### PR DESCRIPTION
Package `./dlna/dms` uses build constraints to differentiate the functions `isHiddenPath` and `isReadablePath`.

However, build constraint `//+build unix` is not valid. The only build constraints that can be used to add an OS constraint are [those equal to a GOOS value](https://golang.org/cmd/go/#hdr-Build_constraints), and `unix` is not [one of them](https://github.com/golang/go/blob/master/src/go/build/syslist.go).

I suppose it meant linux OR darwin, so I updated the build constraints accordingly.

I tested it only on Linux only (on Linux, even if `-ignoreHidden` is provided, it did not filter out hidden files).
