### PR TITLE
Cache on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN \
       ffmpegthumbnailer \
   && \
   apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  touch /root/.dms-ffprobe-cache
 
 COPY . /go/src/github.com/anacrolix/dms/
 WORKDIR /go/src/github.com/anacrolix/dms/


### PR DESCRIPTION
Hi everyone!

I was trying dms with VLC on a folder with about 200 files in docker. Every time it started was too slow to show files. Researching I realized that it is possible to activate the ffprobecache, that is why I have decided to make this pull request by creating the cache file by default.

Demitroi