### PR TITLE
Fixes to make dms work with Samsung TVs and UPnP Monkey on Android

### DIFF
--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -47,7 +47,7 @@ func (me *contentDirectoryService) cdsObjectToUpnpavObject(cdsObject object, fil
 	if fileInfo.IsDir() {
 		obj.Class = "object.container.storageFolder"
 		obj.Title = fileInfo.Name()
-		ret = upnpav.Container{Object: obj}
+		ret = upnpav.Container{Object: obj, ChildCount: me.objectChildCount(cdsObject)}
 		return
 	}
 	if !fileInfo.Mode().IsRegular() {

--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -207,17 +207,17 @@ func (me *contentDirectoryService) objectFromID(id string) (o object, err error)
 	return
 }
 
-func (me *contentDirectoryService) Handle(action string, argsXML []byte, r *http.Request) (map[string]string, error) {
+func (me *contentDirectoryService) Handle(action string, argsXML []byte, r *http.Request) ([][2]string, error) {
 	host := r.Host
 	userAgent := r.UserAgent()
 	switch action {
 	case "GetSystemUpdateID":
-		return map[string]string{
-			"Id": me.updateIDString(),
+		return [][2]string{
+			{"Id", me.updateIDString()},
 		}, nil
 	case "GetSortCapabilities":
-		return map[string]string{
-			"SortCaps": "dc:title",
+		return [][2]string{
+			{"SortCaps", "dc:title"},
 		}, nil
 	case "Browse":
 		var browse browse
@@ -249,11 +249,11 @@ func (me *contentDirectoryService) Handle(action string, argsXML []byte, r *http
 			if err != nil {
 				return nil, err
 			}
-			return map[string]string{
-				"TotalMatches":   fmt.Sprint(totalMatches),
-				"NumberReturned": fmt.Sprint(len(objs)),
-				"Result":         didl_lite(string(result)),
-				"UpdateID":       me.updateIDString(),
+			return [][2]string{
+				{"Result",         didl_lite(string(result))},
+				{"NumberReturned", fmt.Sprint(len(objs))},
+				{"TotalMatches",   fmt.Sprint(totalMatches)},
+				{"UpdateID",       me.updateIDString()},
 			}, nil
 		case "BrowseMetadata":
 			fileInfo, err := os.Stat(obj.FilePath())
@@ -274,18 +274,18 @@ func (me *contentDirectoryService) Handle(action string, argsXML []byte, r *http
 			if err != nil {
 				return nil, err
 			}
-			return map[string]string{
-				"TotalMatches":   "1",
-				"NumberReturned": "1",
-				"Result":         didl_lite(func() string { return string(buf) }()),
-				"UpdateID":       me.updateIDString(),
+			return [][2]string{
+				{"Result",         didl_lite(func() string { return string(buf) }())},
+				{"NumberReturned", "1"},
+				{"TotalMatches",   "1"},
+				{"UpdateID",       me.updateIDString()},
 			}, nil
 		default:
 			return nil, upnp.Errorf(upnp.ArgumentValueInvalidErrorCode, "unhandled browse flag: %v", browse.BrowseFlag)
 		}
 	case "GetSearchCapabilities":
-		return map[string]string{
-			"SearchCaps": "",
+		return [][2]string{
+			{"SearchCaps", ""},
 		}, nil
 	default:
 		return nil, upnp.InvalidActionError

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -252,7 +252,7 @@ type Server struct {
 
 // UPnP SOAP service.
 type UPnPService interface {
-	Handle(action string, argsXML []byte, r *http.Request) (respArgs map[string]string, err error)
+	Handle(action string, argsXML []byte, r *http.Request) (respArgs [][2]string, err error)
 	Subscribe(callback []*url.URL, timeoutSeconds int) (sid string, actualTimeout int, err error)
 	Unsubscribe(sid string) error
 }
@@ -506,9 +506,10 @@ func handleSCPDs(mux *http.ServeMux) {
 }
 
 // Marshal SOAP response arguments into a response XML snippet.
-func marshalSOAPResponse(sa upnp.SoapAction, args map[string]string) []byte {
+func marshalSOAPResponse(sa upnp.SoapAction, args [][2]string) []byte {
 	soapArgs := make([]soap.Arg, 0, len(args))
-	for argName, value := range args {
+	for  _, arg := range args {
+		argName, value := arg[0], arg[1]
 		soapArgs = append(soapArgs, soap.Arg{
 			XMLName: xml.Name{Local: argName},
 			Value:   value,
@@ -518,7 +519,7 @@ func marshalSOAPResponse(sa upnp.SoapAction, args map[string]string) []byte {
 }
 
 // Handle a SOAP request and return the response arguments or UPnP error.
-func (me *Server) soapActionResponse(sa upnp.SoapAction, actionRequestXML []byte, r *http.Request) (map[string]string, error) {
+func (me *Server) soapActionResponse(sa upnp.SoapAction, actionRequestXML []byte, r *http.Request) ([][2]string, error) {
 	service, ok := me.services[sa.Type]
 	if !ok {
 		// TODO: What's the invalid service error?!

--- a/upnpav/upnpav.go
+++ b/upnpav/upnpav.go
@@ -34,9 +34,9 @@ type Object struct {
 	ID          string `xml:"id,attr"`
 	ParentID    string `xml:"parentID,attr"`
 	Restricted  int    `xml:"restricted,attr"` // indicates whether the object is modifiable
+	Title       string `xml:"dc:title"`
 	Class       string `xml:"upnp:class"`
 	Icon        string `xml:"upnp:icon,omitempty"`
-	Title       string `xml:"dc:title"`
 	Artist      string `xml:"upnp:artist,omitempty"`
 	Album       string `xml:"upnp:album,omitempty"`
 	Genre       string `xml:"upnp:genre,omitempty"`


### PR DESCRIPTION
I wanted to make dms work on my Samsung TV, and while debugging against a very hackish Python script I wrote ages ago and which worked found some bugs related to other players as well :slightly_smiling_face:  This PR is an attempt to fix them. Changes are:

* **Sort the SOAP response elements**
  Some XML parsers are picky about the order of elements, even in situations where a container only contains each tag exactly once. (I guess that allows an optimization in auto-generated parsers..) Since right now you use a `map[string]string` for this, which is naturally unordered, I had to refactor some code to use `[][2]string` instead. The order I did use is the one in which the fields are introduced by the specification.
* **Write `dc:title` tag first**
  The specification requires that `item`/`container` DIDL-Lite tags have this tag as their first child. This is required for my Samsung TV.
* **Report correct `childCount` for containers**
  Again, my Samsung TV tries to be overly clever. Since dms reports 0 children, it doesn't bother to actually ever `Browse` the directory. (I am pretty certain that this is wrong and that 0 has some magic meaning, but couldn't find it - anyway, it doesn't harm to report the correct value here.)

Let me know if there's anything you'd like to see changed.

By the way, thanks for writing and maintaining this application! It is really useful for setting up ad-hoc dlna servers :smile: 