### PR TITLE
mimetype: added audio/ogg

### DIFF
--- a/dlna/dms/mimetype.go
+++ b/dlna/dms/mimetype.go
@@ -16,6 +16,9 @@ func init() {
 	if err := mime.AddExtensionType(".ogv", "video/ogg"); err != nil {
 		log.Printf("Could not register video/ogg MIME type: %s", err)
 	}
+	if err := mime.AddExtensionType(".ogg", "audio/ogg"); err != nil {
+		log.Printf("Could not register audio/ogg MIME type: %s", err)
+	}
 }
 
 // Example: "video/mpeg"


### PR DESCRIPTION
My `.ogg` audio files weren't listed so i added `audio/ogg` mimetype.
Works fine with vlc client but seems my tv is missing support for it so it can't play the audio (same as videos with `opus` audio track).
Current transcoding options didn't help, but that's a different issue.