### PR TITLE
get readme image from web archive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ will also provide thumbnails where possible.
 
 dms uses ``ffprobe``/``avprobe`` to get media data such as bitrate and duration, ``ffmpeg``/``avconv`` for video transoding, and ``ffmpegthumbnailer`` for generating thumbnails when browsing. These commands must be in the ``PATH`` given to ``dms`` or the features requiring them will be disabled.
 
-.. image:: https://lh3.googleusercontent.com/-z-zh7AzObGo/UEiWni1cQPI/AAAAAAAAASI/DRw9IoMMiNs/w497-h373/2012%2B-%2B1
+.. image:: https://i.imgur.com/qbHilI7.png
 
 Installing
 ==========


### PR DESCRIPTION
This link has been broken since *at least* 2018...