### PR TITLE
create GitHub action

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -1,0 +1,30 @@
+# .goreleaser.yaml
+builds:
+  # You can have multiple builds defined as a yaml list
+  -
+    # ID of the build.
+    # Defaults to the project name.
+    id: "my-build"
+
+    # Optionally override the matrix generation and specify only the final list of targets.
+    # Format is `{goos}_{goarch}` with optionally a suffix with `_{goarm}` or `_{gomips}`.
+    # This overrides `goos`, `goarch`, `goarm`, `gomips` and `ignores`.
+    targets:
+      - linux_amd64
+      - linux_386
+      - linux_arm_6
+      - linux_arm_7
+      - darwin_arm64
+      - darwin_amd64
+      - windows_arm
+      - windows_amd64
+      - windows_386
+
+    # By default, GoRelaser will create your binaries inside `dist/${BuildID}_${BuildTarget}`, which is an unique directory per build target in the matrix.
+    # You are able to set subdirs within that folder using the `binary` property.
+    #
+    # However, if for some reason you don't want that unique directory to be created, you can set this property.
+    # If you do, you are responsible of keeping different builds from overriding each other.
+    #
+    # Defaults to `false`.
+    #no_unique_dist_dir: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,35 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,3 +33,51 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      -
+        name: Upload artifact dms_linux_arm64
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_linux_arm64
+          path: dist/dms_linux_arm64/dms
+      -
+        name: Upload artifact dms_linux_amd64
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_linux_amd64
+          path: dist/dms_linux_amd64/dms
+      -
+        name: Upload artifact dms_linux_386
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_linux_386
+          path: dist/dms_linux_386/dms
+      -
+        name: Upload artifact dms_linux_arm
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_linux_arm
+          path: dist/dms_linux_arm/dms
+      -
+        name: Upload artifact dms_darwin_arm64
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_darwin_arm64
+          path: dist/dms_darwin_arm64/dms
+      -
+        name: Upload artifact dms_darwin_amd64
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_darwin_amd64
+          path: dist/dms_darwin_amd64/dms
+      -
+        name: Upload artifact dms_darwin_386
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_darwin_386
+          path: dist/dms_darwin_386/dms
+      -
+        name: Upload artifact dms_darwin_arm
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_darwin_arm
+          path: dist/dms_darwin_arm/dms

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,17 +28,11 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --config ${{ github.workspace }}/.github/goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-      -
-        name: Upload artifact dms_linux_arm64
-        uses: actions/upload-artifact@v2
-        with:
-          name: dms_linux_arm64
-          path: dist/dms_linux_arm64/dms
       -
         name: Upload artifact dms_linux_amd64
         uses: actions/upload-artifact@v2
@@ -52,11 +46,17 @@ jobs:
           name: dms_linux_386
           path: dist/dms_linux_386/dms
       -
-        name: Upload artifact dms_linux_arm
+        name: Upload artifact dms_linux_arm_6
         uses: actions/upload-artifact@v2
         with:
-          name: dms_linux_arm
-          path: dist/dms_linux_arm/dms
+          name: dms_linux_arm_6
+          path: dist/dms_linux_arm_6/dms
+      -
+        name: Upload artifact dms_linux_arm_7
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_linux_arm_7
+          path: dist/dms_linux_arm_7/dms
       -
         name: Upload artifact dms_darwin_arm64
         uses: actions/upload-artifact@v2
@@ -70,14 +70,20 @@ jobs:
           name: dms_darwin_amd64
           path: dist/dms_darwin_amd64/dms
       -
-        name: Upload artifact dms_darwin_386
+        name: Upload artifact dms_windows_arm
         uses: actions/upload-artifact@v2
         with:
-          name: dms_darwin_386
-          path: dist/dms_darwin_386/dms
+          name: dms_windows_arm
+          path: dist/dms_windows_arm/dms
       -
-        name: Upload artifact dms_darwin_arm
+        name: Upload artifact dms_windows_amd64
         uses: actions/upload-artifact@v2
         with:
-          name: dms_darwin_arm
-          path: dist/dms_darwin_arm/dms
+          name: dms_windows_amd64
+          path: dist/dms_windows_amd64/dms
+      -
+        name: Upload artifact dms_windows_386
+        uses: actions/upload-artifact@v2
+        with:
+          name: dms_windows_386
+          path: dist/dms_windows_386/dms

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,52 +38,52 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: dms_linux_amd64
-          path: dist/dms_linux_amd64/dms
+          path: dist/my-build_linux_amd64/dms
       -
         name: Upload artifact dms_linux_386
         uses: actions/upload-artifact@v2
         with:
           name: dms_linux_386
-          path: dist/dms_linux_386/dms
+          path: dist/my-build_linux_386/dms
       -
         name: Upload artifact dms_linux_arm_6
         uses: actions/upload-artifact@v2
         with:
           name: dms_linux_arm_6
-          path: dist/dms_linux_arm_6/dms
+          path: dist/my-build_linux_arm_6/dms
       -
         name: Upload artifact dms_linux_arm_7
         uses: actions/upload-artifact@v2
         with:
           name: dms_linux_arm_7
-          path: dist/dms_linux_arm_7/dms
+          path: dist/my-build_linux_arm_7/dms
       -
         name: Upload artifact dms_darwin_arm64
         uses: actions/upload-artifact@v2
         with:
           name: dms_darwin_arm64
-          path: dist/dms_darwin_arm64/dms
+          path: dist/my-build_darwin_arm64/dms
       -
         name: Upload artifact dms_darwin_amd64
         uses: actions/upload-artifact@v2
         with:
           name: dms_darwin_amd64
-          path: dist/dms_darwin_amd64/dms
+          path: dist/my-build_darwin_amd64/dms
       -
-        name: Upload artifact dms_windows_arm
+        name: Upload artifact dms_windows_arm.exe
         uses: actions/upload-artifact@v2
         with:
           name: dms_windows_arm
-          path: dist/dms_windows_arm/dms
+          path: dist/my-build_windows_arm/dms.exe
       -
-        name: Upload artifact dms_windows_amd64
+        name: Upload artifact dms_windows_amd64.exe
         uses: actions/upload-artifact@v2
         with:
           name: dms_windows_amd64
-          path: dist/dms_windows_amd64/dms
+          path: dist/my-build_windows_amd64/dms.exe
       -
-        name: Upload artifact dms_windows_386
+        name: Upload artifact dms_windows_386.exe
         uses: actions/upload-artifact@v2
         with:
           name: dms_windows_386
-          path: dist/dms_windows_386/dms
+          path: dist/my-build_windows_386/dms.exe


### PR DESCRIPTION
This action will provide artifacts in the actions tab on GitHub after every push or pull request[^1]. When a semver tag is pushed[^2], it'll also create a release for it and upload the artifacts to the release. You can see what the release looks like by looking at my fork (`git tag v99.99.99; git push origin v99.99.99` gives you [this](https://github.com/Efreak/dms/releases/tag/v99.99.99)) I'm sure there's a cleaner way to do this, but frankly I've spent hours on this already [^3], and want to go do something else now.

If you want to, you can probably remove the circle ci option now.

[^1]: you can easily remove the pull request option. I left this in because sometimes people (quite often me) don't want too set up a dev environment to fix small issues.
[^2]: it doesn't like tags that aren't semver. It falls. No artifacts are uploaded.
[^3]: I've been lazy about learning GitHub actions until now