### PR TITLE
Add Docker image publish Github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,5 @@
 name: Publish Docker image
 
-env:
-  DOCKERHUB_IMAGE: dms
-
 on: push
 
 jobs:
@@ -11,6 +8,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       # Required if building multi-arch images
       - name: Set up QEMU
@@ -34,6 +43,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/386
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:latest,${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:${{ github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,39 @@
+name: Publish Docker image
+
+env:
+  DOCKERHUB_IMAGE: dms
+
+on: push
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Required if building multi-arch images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - id: buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/386
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:latest,${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Finally, I managed to solve #69 using Github Actions, no need to grant access to Docker Hub to your Github repos, since it will be Github which will build and push the image to DH. :tada:

Github Action requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (generated on [DH's security settings](https://hub.docker.com/settings/security) page) to be set in the Github secrets section in the repo config. 
Git pushes will trigger this Github Action to build Docker images and push them to Docker Hub:
* Git branch `branchname` pushes `dms:branchname` image tag. Thus, `dms:master` acts as an edge/unreleased/HEAD image tag. Other branches push to their respective image tags (useful for testing feature branches),
* Git tags `vX.Y.X` push to `dms:X.Y.Z`, `dms:X.Y`, `dms:X` and `dms:latest`.`:latest` tag is the default if no tag specified, so `docker pull anacrolix/dms` pulls latest released (stable) git tag.

Also enabled Dependabot (only for Github Actions manifests). No need to toggle or configure anything.

Check out [action runs](https://github.com/pataquets/dms/actions) and [image tags](https://hub.docker.com/repository/docker/pataquets/dms/tags) from my testing on my repos.