### PR TITLE
Compatibility with Samsung Frame TVs

### DIFF
--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -592,6 +592,8 @@ func (me *Server) serviceControlHandler(w http.ResponseWriter, r *http.Request) 
 		return marshalSOAPResponse(soapAction, respArgs), 200
 	}()
 	bodyStr := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8" standalone="yes"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body>%s</s:Body></s:Envelope>`, soapRespXML)
+	// Compatibility with Samsung Frame TV's - they don't display an empty content directory without this hack:
+	bodyStr = strings.Replace(bodyStr, "&#34;", `"`, -1)
 	w.WriteHeader(code)
 	if _, err := w.Write([]byte(bodyStr)); err != nil {
 		log.Print(err)


### PR DESCRIPTION
I got a Samsung Frame TV model 2021 (User-Agent: `DLNADOC/1.50 SEC_HHP_Samsung The Frame 50/1.0 UPnP/1.0`).
When browsing to any DMS based DLNA server, it displays an empty content directory.

I went through the painful debugging process and started comparing every piece of the protocol with MiniDLNA responses (that is working smoothly), mismatching case sensitivity in header names, removing non-standard looking fields from the XML responses, forcing the SPCD descriptor to be the same, etc.

The resolution of this issue was to patch the entity encoding of the DIDL-Lite envelope.
