### PR TITLE
new feature: serving streams generated on the fly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,9 @@ dms advertises and serves the raw files, in addition to alternate transcoded
 streams when it's able, such as mpeg2 PAL-DVD and WebM for the Chromecast. It
 will also provide thumbnails where possible.
 
+dms also supports serving streams generated on the fly, e.g. a live rtsp stream
+(with the help of ffmpeg).
+
 dms uses ``ffprobe``/``avprobe`` to get media data such as bitrate and duration, ``ffmpeg``/``avconv`` for video transoding, and ``ffmpegthumbnailer`` for generating thumbnails when browsing. These commands must be in the ``PATH`` given to ``dms`` or the features requiring them will be disabled.
 
 .. image:: https://i.imgur.com/qbHilI7.png

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -592,6 +592,8 @@ func (me *Server) serviceControlHandler(w http.ResponseWriter, r *http.Request) 
 		return marshalSOAPResponse(soapAction, respArgs), 200
 	}()
 	bodyStr := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8" standalone="yes"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body>%s</s:Body></s:Envelope>`, soapRespXML)
+	// Compatibility with Samsung Frame TV's - they don't display an empty content directory without this hack:
+	bodyStr = strings.Replace(bodyStr, "&#34;", `"`, -1)
 	w.WriteHeader(code)
 	if _, err := w.Write([]byte(bodyStr)); err != nil {
 		log.Print(err)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ type dmsConfig struct {
 	IgnoreHidden        bool
 	IgnoreUnreadable    bool
 	AllowedIpNets       []*net.IPNet
+	AllowDynamicStreams bool
 }
 
 func (config *dmsConfig) load(configPath string) {
@@ -65,14 +66,15 @@ func (config *dmsConfig) load(configPath string) {
 
 // default config
 var config = &dmsConfig{
-	Path:             "",
-	IfName:           "",
-	Http:             ":1338",
-	FriendlyName:     "",
-	DeviceIcon:       "",
-	LogHeaders:       false,
-	FFprobeCachePath: getDefaultFFprobeCachePath(),
-	ForceTranscodeTo: "",
+	Path:                "",
+	IfName:              "",
+	Http:                ":1338",
+	FriendlyName:        "",
+	DeviceIcon:          "",
+	LogHeaders:          false,
+	FFprobeCachePath:    getDefaultFFprobeCachePath(),
+	ForceTranscodeTo:    "",
+	AllowDynamicStreams: false,
 }
 
 func getDefaultFFprobeCachePath() (path string) {
@@ -135,6 +137,7 @@ func mainErr() error {
 	flag.DurationVar(&config.NotifyInterval, "notifyInterval", 30*time.Second, "interval between SSPD announces")
 	flag.BoolVar(&config.IgnoreHidden, "ignoreHidden", false, "ignore hidden files and directories")
 	flag.BoolVar(&config.IgnoreUnreadable, "ignoreUnreadable", false, "ignore unreadable files and directories")
+	flag.BoolVar(&config.AllowDynamicStreams, "allowDynamicStreams", false, "allow dynamic streams")
 
 	flag.Parse()
 	if flag.NArg() != 0 {
@@ -201,13 +204,14 @@ func mainErr() error {
 			}
 			return conn
 		}(),
-		FriendlyName:     config.FriendlyName,
-		RootObjectPath:   filepath.Clean(config.Path),
-		FFProbeCache:     cache,
-		LogHeaders:       config.LogHeaders,
-		NoTranscode:      config.NoTranscode,
-		ForceTranscodeTo: config.ForceTranscodeTo,
-		NoProbe:          config.NoProbe,
+		FriendlyName:        config.FriendlyName,
+		RootObjectPath:      filepath.Clean(config.Path),
+		FFProbeCache:        cache,
+		LogHeaders:          config.LogHeaders,
+		NoTranscode:         config.NoTranscode,
+		ForceTranscodeTo:    config.ForceTranscodeTo,
+		AllowDynamicStreams: config.AllowDynamicStreams,
+		NoProbe:             config.NoProbe,
 		Icons: []dms.Icon{
 			{
 				Width:    48,

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -97,6 +97,12 @@ func Transcode(path string, start, length time.Duration, stderr io.Writer) (r io
 	return transcodePipe(args, stderr)
 }
 
+// Streams the desired file in the MPEG_PS_PAL DLNA profile.
+func Exec(path string, start, length time.Duration, stderr io.Writer) (r io.ReadCloser, err error) {
+	args := []string{path}
+	return transcodePipe(args, stderr)
+}
+
 // Returns a stream of Chromecast supported VP8.
 func VP8Transcode(path string, start, length time.Duration, stderr io.Writer) (r io.ReadCloser, err error) {
 	args := []string{


### PR DESCRIPTION
This change allows serving streams generated on the fly, e.g. exporting the live stream of an rtsp camera over DLNA.

Consider the following script (`/mkv-hd.mkv`) in the DMS path (`/dms-data-dir`):

```
#!/bin/sh

exec ffmpeg -i rtsp://10.6.8.161:554/Streaming/Channels/501/ -c:v copy -c:a copy -movflags +faststart+frag_keyframe+empty_moov -f matroska -
```

Would make the camera stream available over DLNA when dms is started with the `-allowDynamicStreams` command line option:

```
./dms -friendlyName live-streams -allowDynamicStreams -path /dms-data-dir/
```

Tested on an LG WebOS 2021 TV.
