### PR TITLE
new feature: live streams generated on the fly via .dms.json

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,9 @@ dms advertises and serves the raw files, in addition to alternate transcoded
 streams when it's able, such as mpeg2 PAL-DVD and WebM for the Chromecast. It
 will also provide thumbnails where possible.
 
+dms also supports serving dynamic streams (e.g. a live rtsp stream) generated 
+on the fly with the help of an external application (e.g. ffmpeg).
+
 dms uses ``ffprobe``/``avprobe`` to get media data such as bitrate and duration, ``ffmpeg``/``avconv`` for video transoding, and ``ffmpegthumbnailer`` for generating thumbnails when browsing. These commands must be in the ``PATH`` given to ``dms`` or the features requiring them will be disabled.
 
 .. image:: https://i.imgur.com/qbHilI7.png
@@ -57,6 +60,8 @@ Usage of dms:
 
    * - parameter
      - description
+   * - ``-allowDynamicStreams``
+     - turns on support for `.dms.json` files in the path
    * - ``-allowedIps string``
      - allowed ip of clients, separated by comma
    * - ``-config string``
@@ -89,3 +94,24 @@ Usage of dms:
      - browse root path
    * - ``-stallEventSubscribe``
      - workaround for some bad event subscribers
+
+Dynamic streams
+===============
+DMS supports "dynamic streams" generated on the fly. This feature can be activated with the
+`-allowDynamicStreams` command line flag and can be configured by placing special metadata
+files in your content directory.
+The name of these metadata files ends with `.dms.json`, their structure is [documented here](https://pkg.go.dev/github.com/anacrolix/dms/dlna/dms)
+
+An example:
+
+```
+{
+  "Title": "My awesome webcam",
+  "Resources": [
+     {
+        "MimeType": "video/webm",
+        "Command": "ffmpeg -i rtsp://10.6.8.161:554/Streaming/Channels/502/ -c:v copy -c:a copy -movflags +faststart+frag_keyframe+empty_moov -f matroska -"
+     }
+  ]
+}
+```

--- a/dlna/dlna.go
+++ b/dlna/dlna.go
@@ -18,6 +18,8 @@ type ContentFeatures struct {
 	SupportRange    bool
 	// Play speeds, DLNA.ORG_PS would go here if supported.
 	Transcoded bool
+	// DLNA.ORG_FLAGS go here if you need to tweak.
+	Flags string
 }
 
 func BinaryInt(b bool) uint {
@@ -41,7 +43,13 @@ func (cf ContentFeatures) String() (ret string) {
 		BinaryInt(cf.SupportTimeSeek),
 		BinaryInt(cf.SupportRange),
 		BinaryInt(cf.Transcoded)))
-	params = append(params, "DLNA.ORG_FLAGS=01700000000000000000000000000000")
+	// https://stackoverflow.com/questions/29182754/c-dlna-generate-dlna-org-flags
+	// DLNA_ORG_FLAG_STREAMING_TRANSFER_MODE | DLNA_ORG_FLAG_BACKGROUND_TRANSFERT_MODE | DLNA_ORG_FLAG_CONNECTION_STALL | DLNA_ORG_FLAG_DLNA_V15
+	flags := "01700000000000000000000000000000"
+	if cf.Flags != "" {
+		flags = cf.Flags
+	}
+	params = append(params, "DLNA.ORG_FLAGS="+flags)
 	return strings.Join(params, ";")
 }
 

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ type dmsConfig struct {
 	IgnoreHidden        bool
 	IgnoreUnreadable    bool
 	AllowedIpNets       []*net.IPNet
+	AllowDynamicStreams bool
 }
 
 func (config *dmsConfig) load(configPath string) {
@@ -135,6 +136,7 @@ func mainErr() error {
 	flag.DurationVar(&config.NotifyInterval, "notifyInterval", 30*time.Second, "interval between SSPD announces")
 	flag.BoolVar(&config.IgnoreHidden, "ignoreHidden", false, "ignore hidden files and directories")
 	flag.BoolVar(&config.IgnoreUnreadable, "ignoreUnreadable", false, "ignore unreadable files and directories")
+	flag.BoolVar(&config.AllowDynamicStreams, "allowDynamicStreams", false, "activate support for dynamic streams described via .dms.json metadata files")
 
 	flag.Parse()
 	if flag.NArg() != 0 {
@@ -201,13 +203,14 @@ func mainErr() error {
 			}
 			return conn
 		}(),
-		FriendlyName:     config.FriendlyName,
-		RootObjectPath:   filepath.Clean(config.Path),
-		FFProbeCache:     cache,
-		LogHeaders:       config.LogHeaders,
-		NoTranscode:      config.NoTranscode,
-		ForceTranscodeTo: config.ForceTranscodeTo,
-		NoProbe:          config.NoProbe,
+		FriendlyName:        config.FriendlyName,
+		RootObjectPath:      filepath.Clean(config.Path),
+		FFProbeCache:        cache,
+		LogHeaders:          config.LogHeaders,
+		NoTranscode:         config.NoTranscode,
+		AllowDynamicStreams: config.AllowDynamicStreams,
+		ForceTranscodeTo:    config.ForceTranscodeTo,
+		NoProbe:             config.NoProbe,
 		Icons: []dms.Icon{
 			{
 				Width:    48,


### PR DESCRIPTION
new feature: live streams generated on the fly via .dms.json config files
bugfix: Samsung Frame TVs crashed when fetching transcoded/live streams due to HEAD request

I can finally watch my cams in HD without transcoding :)
