### PR TITLE
fix   Int63n panic

### DIFF
--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -316,6 +316,10 @@ func (me *Server) handle(buf []byte, sender *net.UDPAddr) {
 	}() {
 		for _, type_ := range types {
 			resp := me.makeResponse(ip, type_, req)
+			//fix mx, if mx<=0 rand.Int63n will be panic
+			if mx <= 0 {
+				mx = 1
+			}
 			delay := time.Duration(rand.Int63n(int64(time.Second) * int64(mx)))
 			me.delayedSend(delay, resp, sender)
 		}

--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -22,6 +22,7 @@ const (
 	rootDevice = "upnp:rootdevice"
 	aliveNTS   = "ssdp:alive"
 	byebyeNTS  = "ssdp:byebye"
+	mxMax      = 10
 )
 
 var NetAddr *net.UDPAddr
@@ -267,7 +268,7 @@ func (me *Server) handle(buf []byte, sender *net.UDPAddr) {
 	if req.Method != "M-SEARCH" || req.Header.Get("man") != `"ssdp:discover"` {
 		return
 	}
-	var mx uint
+	var mx int64
 	if req.Header.Get("Host") == AddrString {
 		mxHeader := req.Header.Get("mx")
 		i, err := strconv.ParseUint(mxHeader, 0, 0)
@@ -275,10 +276,14 @@ func (me *Server) handle(buf []byte, sender *net.UDPAddr) {
 			me.Logger.Printf("Invalid mx header %q: %s", mxHeader, err)
 			return
 		}
-		mx = uint(i)
+		mx = int64(i)
 	}
-	if mx == 0 {
+	// fix mx
+	if mx <= 0 {
 		mx = 1
+	}
+	if mx > mxMax {
+		mx = mxMax
 	}
 	types := func(st string) []string {
 		if st == "ssdp:all" {
@@ -316,11 +321,7 @@ func (me *Server) handle(buf []byte, sender *net.UDPAddr) {
 	}() {
 		for _, type_ := range types {
 			resp := me.makeResponse(ip, type_, req)
-			//fix mx, if mx<=0 rand.Int63n will be panic
-			if mx <= 0 {
-				mx = 1
-			}
-			delay := time.Duration(rand.Int63n(int64(time.Second) * int64(mx)))
+			delay := time.Duration(rand.Int63n(int64(time.Second) * mx))
 			me.delayedSend(delay, resp, sender)
 		}
 	}


### PR DESCRIPTION
2023/11/09 11:05:05 INFO  : /static/ContentDirectory.xml: 192.168.131.174:52716 GET 200  
panic: invalid argument to Int63n

goroutine 1933 [running]:
math/rand.(*Rand).Int63n(0x140000008c0?, 0x14000046e70?)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/math/rand/rand.go:121 +0xe8
math/rand.Int63n(...)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/math/rand/rand.go:348
github.com/anacrolix/dms/ssdp.(*Server).handle(0x140000008c0, {0x14000706c00, 0x65, 0x5dc}, 0x1400057cfc0?)
        /go/pkg/mod/github.com/anacrolix/dms@v1.6.0/ssdp/ssdp.go:319 +0x874
created by github.com/anacrolix/dms/ssdp.(*Server).serve
        /go/pkg/mod/github.com/anacrolix/dms@v1.6.0/ssdp/ssdp.go:129 +0x2c