### PR TITLE
add -ignore option to skip named directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,8 @@ Usage of dms:
      - ignore hidden files and directories
    * - ``-ignoreUnreadable``
      - ignore unreadable files and directories
+   * - ``-ignore``
+     - ignore comma separated list of paths (i.e. -ignore thumbnails,thumbs)
    * - ``-logHeaders``
      - log HTTP headers
    * - ``-noProbe``

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -265,10 +265,10 @@ type Server struct {
 	NotifyInterval time.Duration
 	// Ignore hidden files and directories
 	IgnoreHidden bool
-	// Ingnore unreadable files and directories
+	// Ignore unreadable files and directories
 	IgnoreUnreadable bool
-	// Ingnore comma separated list of directories
-	IgnorePaths string
+	// Ignore comma separated list of directories
+	IgnorePaths []string
 	// White list of clients
 	AllowedIpNets []*net.IPNet
 	// Activate support for dynamic streams configured via .dms.json metadata files
@@ -1114,8 +1114,7 @@ func (server *Server) IgnorePath(path string) (bool, error) {
 		}
 	}
 
-	ignoreList := strings.Split(server.IgnorePaths, ",")
-	for _, element := range ignoreList {
+	for _, element := range server.IgnorePaths {
 		if strings.Contains(path, fmt.Sprintf("/%s/", element)) {
 			log.Print(path, " ignored: in ignore list")
 			return true, nil

--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -267,6 +267,8 @@ type Server struct {
 	IgnoreHidden bool
 	// Ingnore unreadable files and directories
 	IgnoreUnreadable bool
+	// Ingnore comma separated list of directories
+	IgnorePaths string
 	// White list of clients
 	AllowedIpNets []*net.IPNet
 	// Activate support for dynamic streams configured via .dms.json metadata files
@@ -1111,6 +1113,15 @@ func (server *Server) IgnorePath(path string) (bool, error) {
 			return true, nil
 		}
 	}
+
+	ignoreList := strings.Split(server.IgnorePaths, ",")
+	for _, element := range ignoreList {
+		if strings.Contains(path, fmt.Sprintf("/%s/", element)) {
+			log.Print(path, " ignored: in ignore list")
+			return true, nil
+		}
+	}
+
 	return false, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ type dmsConfig struct {
 	NotifyInterval      time.Duration
 	IgnoreHidden        bool
 	IgnoreUnreadable    bool
-	IgnorePaths         string
+	IgnorePaths         []string
 	AllowedIpNets       []*net.IPNet
 	AllowDynamicStreams bool
 	TranscodeLogPattern string
@@ -160,7 +160,7 @@ func mainErr() error {
 	config.FFprobeCachePath = *fFprobeCachePath
 	config.AllowedIpNets = makeIpNets(*allowedIps)
 	config.ForceTranscodeTo = *forceTranscodeTo
-	config.IgnorePaths = *ignorePaths
+	config.IgnorePaths = strings.Split(*ignorePaths, ",")
 	config.TranscodeLogPattern = *transcodeLogPattern
 
 	if config.TranscodeLogPattern == "" {

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ type dmsConfig struct {
 	NotifyInterval      time.Duration
 	IgnoreHidden        bool
 	IgnoreUnreadable    bool
+	IgnorePaths         string
 	AllowedIpNets       []*net.IPNet
 	AllowDynamicStreams bool
 	TranscodeLogPattern string
@@ -139,6 +140,7 @@ func mainErr() error {
 	flag.DurationVar(&config.NotifyInterval, "notifyInterval", 30*time.Second, "interval between SSPD announces")
 	flag.BoolVar(&config.IgnoreHidden, "ignoreHidden", false, "ignore hidden files and directories")
 	flag.BoolVar(&config.IgnoreUnreadable, "ignoreUnreadable", false, "ignore unreadable files and directories")
+	ignorePaths := flag.String("ignore", "", "comma separated list of directories to ignore (i.e. thumbnails,thumbs)")
 	flag.BoolVar(&config.AllowDynamicStreams, "allowDynamicStreams", false, "activate support for dynamic streams described via .dms.json metadata files")
 
 	flag.Parse()
@@ -158,6 +160,7 @@ func mainErr() error {
 	config.FFprobeCachePath = *fFprobeCachePath
 	config.AllowedIpNets = makeIpNets(*allowedIps)
 	config.ForceTranscodeTo = *forceTranscodeTo
+	config.IgnorePaths = *ignorePaths
 	config.TranscodeLogPattern = *transcodeLogPattern
 
 	if config.TranscodeLogPattern == "" {
@@ -247,6 +250,7 @@ func mainErr() error {
 		NotifyInterval:      config.NotifyInterval,
 		IgnoreHidden:        config.IgnoreHidden,
 		IgnoreUnreadable:    config.IgnoreUnreadable,
+		IgnorePaths:         config.IgnorePaths,
 		AllowedIpNets:       config.AllowedIpNets,
 	}
 	if err := dmsServer.Init(); err != nil {


### PR DESCRIPTION
This adds an `-ignore` option which lets you ignore directories by name, an extension to the `-ignoreHidden` option already present. Useful if you have, say, a `thumbs/` subdirectory or a `metadata/` subdirectory that you don't want to be listed or served.