### PR TITLE
Fix concurrent map read/write race condition

### DIFF
--- a/upnp/eventing.go
+++ b/upnp/eventing.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/anacrolix/log"
@@ -47,10 +48,14 @@ type subscriber struct {
 // Intended to eventually be an embeddable implementation for managing
 // eventing for a service. Not complete.
 type Eventing struct {
+	mutex       sync.Mutex
 	subscribers map[string]*subscriber
 }
 
 func (me *Eventing) Subscribe(callback []*url.URL, timeoutSeconds int) (sid string, actualTimeout int, err error) {
+	me.mutex.Lock()
+	defer me.mutex.Unlock()
+
 	var uuid [16]byte
 	io.ReadFull(rand.Reader, uuid[:])
 	sid = FormatUUID(uuid[:])

--- a/upnp/eventing_test.go
+++ b/upnp/eventing_test.go
@@ -40,3 +40,22 @@ func TestParseCallbackURLs(t *testing.T) {
 		t.Fatal(len(urls))
 	}
 }
+
+func TestSubscribeRace(t *testing.T) {
+	const n = 100
+
+	e := &Eventing{}
+	done := make(chan struct{})
+
+	doSubscribes := func() {
+		for i := 0; i < n; i++ {
+			e.Subscribe(nil, 10)
+		}
+		done <- struct{}{}
+	}
+
+	go doSubscribes()
+	go doSubscribes()
+	<-done
+	<-done
+}


### PR DESCRIPTION
Fixes a race condition in `upnp.Eventing.Subscribe` which would cause a concurrent map read/write panic.