### PR TITLE
Fix confusing startup log

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,14 +171,14 @@ func mainErr() error {
 		config.TranscodeLogPattern = filepath.Join(u.HomeDir, ".dms", "log", "[tsname]")
 	}
 
+	if len(*configFilePath) > 0 {
+		config.load(*configFilePath)
+	}
+
 	logger.Printf("allowed ip nets are %q", config.AllowedIpNets)
 	logger.Printf("serving folder %q", config.Path)
 	if(config.AllowDynamicStreams) {
 		logger.Printf("Dynamic streams ARE allowed")
-	}
-
-	if len(*configFilePath) > 0 {
-		config.load(*configFilePath)
 	}
 
 	cache := &fFprobeCache{


### PR DESCRIPTION
During startup, DMS prints things like path being served or default network

However it does so _before_ parsing the configuration JSON file, if one was providing, thus generating confusing output.

