### PR TITLE
Print device icon sizes after config load

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,6 @@ func mainErr() error {
 	config.FriendlyName = *friendlyName
 	config.DeviceIcon = *deviceIcon
 	config.DeviceIconSizes = strings.Split(*deviceIconSizes, ",")
-	logger.Printf("device icon sizes are %q", config.DeviceIconSizes)
 
 	config.LogHeaders = *logHeaders
 	config.FFprobeCachePath = *fFprobeCachePath
@@ -182,6 +181,7 @@ func mainErr() error {
 		config.load(*configFilePath)
 	}
 
+	logger.Printf("device icon sizes are %q", config.DeviceIconSizes)
 	logger.Printf("allowed ip nets are %q", config.AllowedIpNets)
 	logger.Printf("serving folder %q", config.Path)
 	if config.AllowDynamicStreams {


### PR DESCRIPTION
This means that if device icon sizes are specified in a json config file
the correct sizes will be printed.