### PR TITLE
Fix ssdp.Server.Serve not returning when closed

### DIFF
--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -148,6 +148,12 @@ func (me *Server) Close() {
 func (me *Server) Serve() (err error) {
 	go me.serve()
 	for {
+		select {
+		case <-me.closed:
+			return
+		default:
+		}
+
 		addrs, err := me.Interface.Addrs()
 		if err != nil {
 			return err


### PR DESCRIPTION
After calling `ssdp.Server.Close` the `Serve` function never returns unless it encounters an error. This causes a goroutine leak in `dms.Server.ssdpInterface`.