### PR TITLE
Use file modified timestamp for dynamic streams

### DIFF
--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -112,6 +112,7 @@ func (me *contentDirectoryService) cdsObjectDynamicStreamToUpnpavObject(cdsObjec
 	if obj.Title == "" {
 		obj.Title = strings.TrimSuffix(fileInfo.Name(), dmsMetadataSuffix)
 	}
+	obj.Date = upnpav.Timestamp{Time: fileInfo.ModTime()}
 
 	item := upnpav.Item{
 		Object: obj,


### PR DESCRIPTION
Set timestamp for dynamic streams from the file modified timestamp.
This is useful for sorting. I use it in Kodi to sort streams by time. 