### PR TITLE
Update install command in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Installing
 
 Assuming ``$GOPATH`` and Go have been configured already::
 
-    $ go get github.com/anacrolix/dms
+    $ go install github.com/anacrolix/dms@latest
 
 Ensure ``ffmpeg``/``avconv`` and/or ``ffmpegthumbnailer`` are in the ``PATH`` if the features depending on them are desired.
 


### PR DESCRIPTION
This is identical to what it did before, but will work on current Go versions.