### PR TITLE
fix: time.After leaks memory

### DIFF
--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -226,10 +226,14 @@ func (me *Server) send(buf []byte, addr *net.UDPAddr) {
 
 func (me *Server) delayedSend(delay time.Duration, buf []byte, addr *net.UDPAddr) {
 	go func() {
+		timer := time.NewTimer(delay)
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
 			me.send(buf, addr)
 		case <-me.closed:
+			if !timer.Stop() {
+				<-timer.C
+			}
 		}
 	}()
 }


### PR DESCRIPTION
It's a relatively common footgun in Go that `time.After` causes the
object and the goroutine to leak.
On my system that leads to reproducible OOM situations, to the point I
had to disable the service because it exhausts memory in a matter of a
few minutes.

This fixes one leak, but there seems to be yet another one: memory use
keeps growing over time, just not as quickly now.
