### PR TITLE
fix goreleaser

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -8,3 +8,5 @@ builds:
     - arm64
     - amd64
     - arm
+upx:
+  - enabled: true

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -10,3 +10,5 @@ builds:
     - arm
 upx:
   - enabled: true
+archives:
+  - format: binary

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,0 +1,10 @@
+builds:
+  - goos:
+    - darwin
+    - windows
+    - linux
+    - freebsd
+    goarch:
+    - arm64
+    - amd64
+    - arm

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -26,7 +26,7 @@ jobs:
           distribution: goreleaser
           # 'latest', 'nightly', or a semver
           version: '~> v2'
-          args: release --clean
+          args: release --clean -f .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -2,6 +2,7 @@ name: goreleaser
 
 on:
   release:
+    types: [published]
 
 permissions:
   contents: write

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,33 @@
+name: goreleaser
+
+on:
+  tag:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          # 'latest', 'nightly', or a semver
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,7 +1,7 @@
 name: goreleaser
 
 on:
-  tag:
+  release:
 
 permissions:
   contents: write


### PR DESCRIPTION
- **add goreleaser again**
- **run on release**
- **add goos matrix**
- **add upx**
- **directly upload binaries, don't zip them**
- **only run the action once**

I've included binaries for 3 main architectures (amd64, arm64, and arm for old NAS), and for 4 OS: Windows, Linux, macos, and freebsd (because freebsd is mentioned in the readme). goreleaser is smart enough not to build impossible armv7 macos, but it builds an unnecessary armv7 windows binary that I haven't bothered to remove.

goreleaser can do a bunch of other stuff as well
- create installers and publish them to winget, chocolatey, scoop
- Linux packages (include completions and man pages?)
- publish releases automatically on github when you create a tag
