### PR TITLE
fix(docker): improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM docker.io/alpine:edge AS build
-WORKDIR /dms
-ADD . /dms
-RUN apk add --no-cache go gcc musl-dev
-RUN go mod tidy 
-RUN go build -trimpath -buildmode=pie -ldflags="-s -w" -o dms
 
+RUN apk add --no-cache --update go gcc
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -buildmode=pie -ldflags="-s -w" -o bin/dms .
 
-FROM docker.io/alpine:edge
-COPY --from=build --chown=1000:1000 /dms/dms /dms
-RUN apk add --no-cache ffmpeg ffmpegthumbnailer mailcap
-RUN adduser user || true
-USER user:user
+FROM docker.io/alpine:edge AS prod
+
+RUN addgroup -S user && \
+    adduser -S -G user user
 WORKDIR /dmsdir
 VOLUME /dmsdir
+RUN chown -R user:user /dmsdir
+RUN apk add --no-cache \
+    ffmpeg ffmpegthumbnailer mailcap
+COPY --from=build /build/bin/dms /dms
+USER user:user
+
 ENTRYPOINT ["/dms"]


### PR DESCRIPTION
There is currently no way to pass custom runtime arguments to the `dms` binary when running with Docker.

This PR revamps the `Dockerfile` and adds `$DMS_FLAGS`, the content of which is passed to the `ENTRYPOINT` in the `Dockerfile`, which makes it possible to pass custom arguments to the binary.

```shell
docker run -d -e DMS_FLAGS='-friendlyName someName' ghcr.io/anacrolix/dms:latest
```

I also added an example to the `README.rst` file that reflects this change.
