### PR TITLE
Fix allowedIps config file parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,8 @@ type dmsConfig struct {
 	IgnoreHidden        bool
 	IgnoreUnreadable    bool
 	IgnorePaths         []string
-	AllowedIpNets       []*net.IPNet
+	AllowedIps          string       // Comma-separated IPs/CIDRs for JSON config
+	AllowedIpNets       []*net.IPNet `json:"-"` // Parsed IP networks, not directly from JSON
 	AllowDynamicStreams bool
 	TranscodeLogPattern string
 }
@@ -179,6 +180,10 @@ func mainErr() error {
 
 	if len(*configFilePath) > 0 {
 		config.load(*configFilePath)
+		// Parse AllowedIps from config file if provided
+		if config.AllowedIps != "" {
+			config.AllowedIpNets = makeIpNets(config.AllowedIps)
+		}
 	}
 
 	logger.Printf("device icon sizes are %q", config.DeviceIconSizes)


### PR DESCRIPTION
The allowedIps option worked from command line but failed from config file because net.IPNet doesn't support JSON unmarshaling. Added a string field AllowedIps for JSON config that gets parsed via makeIpNets() after loading the config file.

Fixes #175