### PR TITLE
Advertise external srt subtitle as text/srt

### DIFF
--- a/dlna/dms/cds.go
+++ b/dlna/dms/cds.go
@@ -301,7 +301,7 @@ func (me *contentDirectoryService) cdsObjectToUpnpavObject(
 					"path": {cdsObject.Path},
 				}.Encode(),
 			}).String(),
-			ProtocolInfo: "http-get:*:text/plain",
+			ProtocolInfo: "http-get:*:text/srt:*",
 		})
 	}
 	if mimeType.IsVideo() || mimeType.IsImage() {


### PR DESCRIPTION
The subtitle resource for a video item was advertised with the protocolInfo `http-get:*:text/plain`. Kodi ignores this and as a result does not render the subtitles. Advertising as `http-get:*:text/srt:*` instead makes Kodi pick up and render the subtitles, whiles VLC continues to work.

Validated manually against stock v1.6.0 (by binary patching the string :o):
- before: subtitles work in VLC, not in Kodi
- after: subtitles work in VLC and Kodi

References for text/srt being the expected subtitle protocolInfo:
- https://stackoverflow.com/questions/14305855
- https://stackoverflow.com/questions/14327977

I suspect it might fix #140 as well.