### PR TITLE
Unbreak build on OpenBSD

### DIFF
--- a/dlna/dms/dms_others.go
+++ b/dlna/dms/dms_others.go
@@ -1,5 +1,5 @@
-//go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
+//go:build !linux && !darwin && !windows && !openbsd
+// +build !linux,!darwin,!windows,!openbsd
 
 package dms
 

--- a/dlna/dms/dms_unix.go
+++ b/dlna/dms/dms_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux || darwin || openbsd
+// +build linux darwin openbsd
 
 package dms
 


### PR DESCRIPTION
Not sure if related to a259fcd
  Fix build for platforms other than Linux, macOS and Windows
but 1.8.0 fails thusly without this:

dlna/dms/dms_others.go:10:6: isReadablePath redeclared in this block
        dlna/dms/dms.go:1154:6: other declaration of isReadablePath
dlna/dms/dms_others.go:11:9: undefined: tryToOpenPath
dlna/dms/dms.go:1128:45: too many arguments in call to isHiddenPath
        have (fs.FS, string)
        want (string)

The project mentions FreeBSD support, but none of the .go files have
in/excludes for `freebsd`, so other BSDs might need amending, too.
