### PR TITLE
Unbreak ffprobe for IPv6-only HTTP listener addresses

### DIFF
--- a/dlna/dms/dms.go
+++ b/dlna/dms/dms.go
@@ -1112,7 +1112,7 @@ func (srv *Server) ffmpegProbe(path string) (info *ffprobe.Info, err error) {
 	key := ffmpegInfoCacheKey{path, fi.ModTime().UnixNano()}
 	value, ok := srv.FFProbeCache.Get(key)
 	if !ok {
-		uri := fmt.Sprintf("http://127.0.0.1:%d%s?path=%s", srv.httpPort(), resPath, path)
+		uri := fmt.Sprintf("http://localhost:%d%s?path=%s", srv.httpPort(), resPath, path)
 		info, err = ffprobe.Run(uri)
 		err = suppressFFmpegProbeDataErrors(err)
 		srv.FFProbeCache.Set(key, info)


### PR DESCRIPTION
`-http [::]:1338` as demonstrated in FAQ.md and discussed in
https://github.com/anacrolix/dms/pull/171 may not resolve to 127.0.0.1:

INFO error probing path=... error="exit status 1: http://127.0.0.1:1338/res?path=...: Connection refused"

Compared to the port, the address is not as easily extracted, so use
"localhost" instead to defer the choice of address family to ffprobe(1)
resolving it through the OS.

Non-localhost addresses or (broken) DNS may still cause probes to fail,
but this still seems like a strict improvement for systems like OpenBSD.
